### PR TITLE
Update ricu path to fix issue with MIMIC IV 2.0

### DIFF
--- a/Python/renv.lock
+++ b/Python/renv.lock
@@ -398,14 +398,14 @@
     },
     "ricu": {
       "Package": "ricu",
-      "Version": "0.5.3",
+      "Version": "0.5.5",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
       "RemoteRef": "monkeypatch",
-      "RemoteSha": "1942e933c4a3ec94c34b55c9b2ffdc3f9c21f174",
+      "RemoteSha": "b75882daab2c3f170f31a6df78163aaf93314b0d",
       "Requirements": [
         "R",
         "assertthat",

--- a/R/renv.lock
+++ b/R/renv.lock
@@ -398,14 +398,14 @@
     },
     "ricu": {
       "Package": "ricu",
-      "Version": "0.5.3",
+      "Version": "0.5.5",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
       "RemoteRef": "monkeypatch",
-      "RemoteSha": "1942e933c4a3ec94c34b55c9b2ffdc3f9c21f174",
+      "RemoteSha": "b75882daab2c3f170f31a6df78163aaf93314b0d",
       "Requirements": [
         "R",
         "assertthat",


### PR DESCRIPTION
This PR updates the `ricu` version in the `renv.lock` files, addressing the problem raised in #5. See also [this commit](https://github.com/prockenschaub/ricu-package/blob/monkeypatch/inst/extdata/config/data-sources.json) in the accompanying `ricu` fork. 

Note that YAIB currently relies on a `ricu` fork hosted at [https://github.com/prockenschaub/ricu-package](https://github.com/prockenschaub/ricu-package). This is because certain features necessary for the development of YAIB were not available in `ricu`. We are currently actively working on integrating those changes into the main `ricu` package.