### PR TITLE
Resolve discrepancies between Python and R preprocessing

### DIFF
--- a/Python/aki.py
+++ b/Python/aki.py
@@ -163,8 +163,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/aki', help='path where to store extracted data',
-                        choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
+    parser.add_argument('--out_dir', default='../data/aki', help='path where to store extracted data')
     args = parser.parse_known_args()[0]
 
     (outc, dyn, sta), attrition = create_aki_task(args)

--- a/Python/kidney_function.py
+++ b/Python/kidney_function.py
@@ -131,8 +131,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/kidney_function', help='path where to store extracted data',
-                        choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
+    parser.add_argument('--out_dir', default='../data/kidney_function', help='path where to store extracted data')
     args = parser.parse_known_args()[0]
 
     (outc, dyn, sta), attrition = create_kf_task(args)

--- a/Python/los.py
+++ b/Python/los.py
@@ -123,8 +123,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/los', help='path where to store extracted data',
-                        choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
+    parser.add_argument('--out_dir', default='../data/los', help='path where to store extracted data')
     args = parser.parse_known_args()[0]
 
     (outc, dyn, sta), attrition = create_los_task(args)

--- a/Python/mortality.py
+++ b/Python/mortality.py
@@ -35,15 +35,17 @@ def create_mortality_task(args):
     time_of_death = load_mortality.perform()
     time_of_death = time_of_death[time_of_death[outc_var] == True]
     
-    patients = stay_windows(args.src)
-    patients = stop_window_at(patients, end=24)
+    base_patients = stay_windows(args.src)
+    base_patients = stop_window_at(base_patients, end=168)
+
+    patients = stop_window_at(base_patients.copy(), end=24)
     patients = stop_window_at(patients, end=time_of_death)
 
     print('   Define exclusion criteria')
     # General exclusion criteria
     excl1 = SelectionCriterion('Invalid length of stay')
     excl1.add_step([
-        InputStep(patients),
+        InputStep(base_patients),
         FilterStep('end', lambda x: x < 0)
     ])
 
@@ -63,7 +65,7 @@ def create_mortality_task(args):
     excl4 = SelectionCriterion('More than 12 hour gap between measurements')
     excl4.add_step([
         load_dynamic, 
-        CustomStep(make_grid_mapper(patients, step_size=1)),
+        CustomStep(make_grid_mapper(base_patients, step_size=1)),
         CustomStep(n_obs_per_row),
         TransformStep('n', lambda x: x > 0), 
         AggStep('stay_id', longest_rle, 'n'),

--- a/Python/mortality.py
+++ b/Python/mortality.py
@@ -129,8 +129,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/mortality24', help='path where to store extracted data',
-                        choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
+    parser.add_argument('--out_dir', default='../data/mortality24', help='path where to store extracted data')
     args = parser.parse_known_args()[0]
 
     (outc, dyn, sta), attrition = create_mortality_task(args)

--- a/Python/mortality.py
+++ b/Python/mortality.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/mortality', help='path where to store extracted data',
+    parser.add_argument('--out_dir', default='../data/mortality24', help='path where to store extracted data',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
     args = parser.parse_known_args()[0]
 

--- a/Python/renv.lock
+++ b/Python/renv.lock
@@ -405,7 +405,7 @@
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
       "RemoteRef": "monkeypatch",
-      "RemoteSha": "b75882daab2c3f170f31a6df78163aaf93314b0d",
+      "RemoteSha": "caee690352e76173ec0532a646d7310be7e1632b",
       "Requirements": [
         "R",
         "assertthat",

--- a/Python/sepsis.py
+++ b/Python/sepsis.py
@@ -147,8 +147,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--src', default='mimic_demo', help='name of datasource',
                         choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
-    parser.add_argument('--out_dir', default='../data/sepsis', help='path where to store extracted data',
-                        choices=['aumc', 'eicu', 'eicu_demo', 'hirid', 'mimic', 'mimic_demo', 'miiv'])
+    parser.add_argument('--out_dir', default='../data/sepsis', help='path where to store extracted data')
     args = parser.parse_known_args()[0]
 
     (outc, dyn, sta), attrition = create_sepsis_task(args)

--- a/Python/src/ricu_utils.py
+++ b/Python/src/ricu_utils.py
@@ -51,6 +51,8 @@ def make_grid_mapper(grid: pd.DataFrame, step_size: int = 1, match_time: bool = 
     grid['time'] = grid.apply(lambda row: list(range(int(row['start']), int(row['end'])+1, step_size)), axis=1)
     grid = grid.drop(['start', 'end'], axis=1)
     grid = grid.explode('time')
+    grid['time'] = grid['time'].astype(float)
+    grid = grid[~np.isnan(grid['time'])]
     grid['time'] = grid['time'].astype(int)
 
     def map_to_grid(x: pd.DataFrame) -> pd.DataFrame:

--- a/Python/src/ricu_utils.py
+++ b/Python/src/ricu_utils.py
@@ -102,7 +102,10 @@ def longest_rle(x: pd.Series, value: bool | int | str = False) -> int:
         run size
     """
     lengths = (x != x.shift()).astype(int).cumsum()
-    return lengths[x == value].value_counts().max()
+    max_rle = lengths[x == value].value_counts().max()
+    if np.isnan(max_rle):
+        max_rle = 0
+    return max_rle
 
 def make_prevalence_calculator(var: str) -> Callable:
     """Calculate the prevalence of a condition by hospital (e.g., sepsis)

--- a/R/renv.lock
+++ b/R/renv.lock
@@ -405,7 +405,7 @@
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
       "RemoteRef": "monkeypatch",
-      "RemoteSha": "b75882daab2c3f170f31a6df78163aaf93314b0d",
+      "RemoteSha": "caee690352e76173ec0532a646d7310be7e1632b",
       "Requirements": [
         "R",
         "assertthat",


### PR DESCRIPTION
### Problem

Issue rvandewater/YAIB#144 was raised in the main YAIB repo, highlighting data inconsistencies between Python and R data preprocessing for the mortality task. This difference is caused by the fact that the Python code did not use a base cohort, restricting the observation time too early. This affects all tasks with a maximum length of 24 hours (i.e., `mortality24` and `kidney_function`). 

In addition, some further differences were found in the calcuation of maximum gap between consecutive measurements. 

### Solution
Introduce a base cohort for `mortality24` and `kidney_function`.





