### PR TITLE
Update to ricu 0.6.0

### DIFF
--- a/Python/renv.lock
+++ b/Python/renv.lock
@@ -398,14 +398,14 @@
     },
     "ricu": {
       "Package": "ricu",
-      "Version": "0.5.5",
+      "Version": "0.6.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
-      "RemoteRef": "monkeypatch",
-      "RemoteSha": "caee690352e76173ec0532a646d7310be7e1632b",
+      "RemoteRef": "monkeypatch0.6.0",
+      "RemoteSha": "0969a52747c71ae9f47051d640caa5df2d5169a0",
       "Requirements": [
         "R",
         "assertthat",

--- a/R/renv.lock
+++ b/R/renv.lock
@@ -398,14 +398,14 @@
     },
     "ricu": {
       "Package": "ricu",
-      "Version": "0.5.5",
+      "Version": "0.6.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "ricu-package",
       "RemoteUsername": "prockenschaub",
-      "RemoteRef": "monkeypatch",
-      "RemoteSha": "caee690352e76173ec0532a646d7310be7e1632b",
+      "RemoteRef": "monkeypatch0.6.0",
+      "RemoteSha": "0969a52747c71ae9f47051d640caa5df2d5169a0",
       "Requirements": [
         "R",
         "assertthat",


### PR DESCRIPTION
This integrates the latest updates in `ricu`. As not all bugs fixed in YAIB have been integrated into the main `ricu` package, we unfortunately still rely on a monkeypatch in [prockenschaub/ricu-package](https://github.com/prockenschaub/ricu-package). We hope to integrate them with the main distribution soon. 

Note that in order to obtain the exact published numbers, please use the following specification in the `renv.lock` file instead: 

```json

"ricu": {
      "Package": "ricu",
      "Version": "0.5.3",
      "Source": "GitHub",
      "RemoteType": "github",
      "RemoteHost": "api.github.com",
      "RemoteRepo": "ricu-package",
      "RemoteUsername": "prockenschaub",
      "RemoteRef": "monkeypatch",
      "RemoteSha": "70dd2e65c3598b6108355fd98fd740a8347840ea",
      "Requirements": [
        "R",
        "assertthat",
        "backports",
        "cli",
        "curl",
        "data.table",
        "fansi",
        "fst",
        "jsonlite",
        "methods",
        "openssl",
        "prt",
        "readr",
        "rlang",
        "stats",
        "tibble",
        "utils",
        "vctrs"
      ],
      "Hash": "2681cdea2f2f3446691071ea30f745b5"
    }

```